### PR TITLE
Update linked hashmap to 0.5.3

### DIFF
--- a/json_typegen_shared/Cargo.toml
+++ b/json_typegen_shared/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = { version = "1.0", features = ["preserve_order"] }
 reqwest = { version = "0.9", optional = true }
 error-chain = "0.12.1"
 lazy_static = "1.2"
-linked-hash-map = "0.5.1"
+linked-hash-map = "0.5.3"
 Inflector = "0.11"
 regex = "1.1"
 syn = { version = "0.11", features = ["full", "parsing"] }


### PR DESCRIPTION
versions 0.5.1 & 0.5.2 are unsound for linked_hashmap. Bumping this will ensure that dependents are always on a sound version. 

Advisory: https://github.com/RustSec/advisory-db/issues/298

