### PR TITLE
Added option to create an alias instead of panicking when encountering a preexisting type

### DIFF
--- a/json_typegen_shared/src/generation/kotlin.rs
+++ b/json_typegen_shared/src/generation/kotlin.rs
@@ -5,8 +5,7 @@ use std::collections::HashSet;
 
 use crate::options::{Options, StringTransform};
 use crate::shape::{self, Shape};
-use crate::util::type_case;
-use crate::util::{kebab_case, lower_camel_case, snake_case};
+use crate::util::{alias, kebab_case, lower_camel_case, snake_case, type_case};
 
 pub struct Ctxt {
     options: Options,
@@ -22,7 +21,8 @@ pub fn kotlin_types(name: &str, shape: &Shape, options: Options) -> (Ident, Opti
         type_names: HashSet::new(),
     };
 
-    type_from_shape(&mut ctxt, name, shape)
+    let (ident, code) = type_from_shape(&mut ctxt, name, shape);
+    alias(ident, name, code, &ctxt.options)
 }
 
 fn type_from_shape(ctxt: &mut Ctxt, path: &str, shape: &Shape) -> (Ident, Option<Code>) {
@@ -105,22 +105,84 @@ fn type_name(name: &str, used_names: &HashSet<String>) -> Ident {
 // https://kotlinlang.org/docs/reference/keyword-reference.html
 const KOTLIN_KEYWORDS_ARR: &[&str] = &[
     // Hard
-    "as", "break", "class", "continue", "do", "else", "false", "for", "fun", "if", "in",
-    "interface", "is", "null", "object", "package", "return", "super", "this", "throw", "true",
-    "try", "typealias", "val", "var", "when", "while",
-
+    "as",
+    "break",
+    "class",
+    "continue",
+    "do",
+    "else",
+    "false",
+    "for",
+    "fun",
+    "if",
+    "in",
+    "interface",
+    "is",
+    "null",
+    "object",
+    "package",
+    "return",
+    "super",
+    "this",
+    "throw",
+    "true",
+    "try",
+    "typealias",
+    "val",
+    "var",
+    "when",
+    "while",
     // Soft
-    "by", "catch", "constructor", "delegate", "dynamic", "field", "file", "finally", "get",
-    "import", "init", "param", "property", "receiver", "set", "setparam", "where",
-
+    "by",
+    "catch",
+    "constructor",
+    "delegate",
+    "dynamic",
+    "field",
+    "file",
+    "finally",
+    "get",
+    "import",
+    "init",
+    "param",
+    "property",
+    "receiver",
+    "set",
+    "setparam",
+    "where",
     // Modifier
-    "actual", "abstract", "annotation", "companion", "const", "crossinline", "data", "enum",
-    "expect", "external", "final", "infix", "inline", "inner", "internal", "lateinit", "noinline",
-    "open", "operator", "out", "override", "private", "protected", "public", "reified", "sealed",
-    "suspend", "tailrec", "vararg",
-
+    "actual",
+    "abstract",
+    "annotation",
+    "companion",
+    "const",
+    "crossinline",
+    "data",
+    "enum",
+    "expect",
+    "external",
+    "final",
+    "infix",
+    "inline",
+    "inner",
+    "internal",
+    "lateinit",
+    "noinline",
+    "open",
+    "operator",
+    "out",
+    "override",
+    "private",
+    "protected",
+    "public",
+    "reified",
+    "sealed",
+    "suspend",
+    "tailrec",
+    "vararg",
     // Special
-    "field", "it"
+    "field",
+    "it",
 ];
 
 lazy_static! {

--- a/json_typegen_shared/src/generation/rust.rs
+++ b/json_typegen_shared/src/generation/rust.rs
@@ -7,7 +7,7 @@ use unindent::unindent;
 use crate::generation::serde_case::RenameRule;
 use crate::options::{Options, StringTransform};
 use crate::shape::{self, Shape};
-use crate::util::{snake_case, type_case};
+use crate::util::{alias, snake_case, type_case};
 
 pub struct Ctxt {
     options: Options,
@@ -54,7 +54,8 @@ pub fn rust_types(name: &str, shape: &Shape, options: Options) -> (Ident, Option
         type_names: HashSet::new(),
     };
 
-    type_from_shape(&mut ctxt, name, shape)
+    let (ident, code) = type_from_shape(&mut ctxt, name, shape);
+    alias(ident, name, code, &ctxt.options)
 }
 
 fn type_from_shape(ctxt: &mut Ctxt, path: &str, shape: &Shape) -> (Ident, Option<Code>) {

--- a/json_typegen_shared/src/generation/rust.rs
+++ b/json_typegen_shared/src/generation/rust.rs
@@ -136,8 +136,7 @@ const RUST_KEYWORDS_ARR: &[&str] = &[
 ];
 
 lazy_static! {
-    static ref RUST_KEYWORDS: HashSet<&'static str> =
-        RUST_KEYWORDS_ARR.iter().cloned().collect();
+    static ref RUST_KEYWORDS: HashSet<&'static str> = RUST_KEYWORDS_ARR.iter().cloned().collect();
 }
 
 fn type_or_field_name(

--- a/json_typegen_shared/src/generation/typescript.rs
+++ b/json_typegen_shared/src/generation/typescript.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 
 use crate::options::Options;
 use crate::shape::{self, Shape};
-use crate::util::type_case;
+use crate::util::{alias, type_case};
 
 pub struct Ctxt {
     options: Options,
@@ -22,7 +22,8 @@ pub fn typescript_types(name: &str, shape: &Shape, options: Options) -> (Ident, 
         type_names: HashSet::new(),
     };
 
-    type_from_shape(&mut ctxt, name, shape)
+    let (ident, code) = type_from_shape(&mut ctxt, name, shape);
+    alias(ident, name, code, &ctxt.options)
 }
 
 fn type_from_shape(ctxt: &mut Ctxt, path: &str, shape: &Shape) -> (Ident, Option<Code>) {
@@ -117,16 +118,56 @@ fn collapse_option(typ: &Shape) -> (bool, &Shape) {
     (false, typ)
 }
 
-const RESERVED_WORDS_ARR: &[&str] = &["break", "case", "catch", "class", "const",
-    "continue", "debugger", "default", "delete", "do", "else", "enum", "export", "extends", "false",
-    "finally", "for", "function", "if", "import", "in", "instanceof", "new", "null", "return",
-    "super", "switch", "this", "throw", "true", "try", "typeof", "var", "void", "while", "with",
-    "implements", "interface", "let", "package", "private", "protected", "public", "static",
-    "yield"];
+const RESERVED_WORDS_ARR: &[&str] = &[
+    "break",
+    "case",
+    "catch",
+    "class",
+    "const",
+    "continue",
+    "debugger",
+    "default",
+    "delete",
+    "do",
+    "else",
+    "enum",
+    "export",
+    "extends",
+    "false",
+    "finally",
+    "for",
+    "function",
+    "if",
+    "import",
+    "in",
+    "instanceof",
+    "new",
+    "null",
+    "return",
+    "super",
+    "switch",
+    "this",
+    "throw",
+    "true",
+    "try",
+    "typeof",
+    "var",
+    "void",
+    "while",
+    "with",
+    "implements",
+    "interface",
+    "let",
+    "package",
+    "private",
+    "protected",
+    "public",
+    "static",
+    "yield",
+];
 
 lazy_static! {
-    static ref RESERVED_WORDS: HashSet<&'static str> =
-        RESERVED_WORDS_ARR.iter().cloned().collect();
+    static ref RESERVED_WORDS: HashSet<&'static str> = RESERVED_WORDS_ARR.iter().cloned().collect();
 }
 
 fn is_ts_identifier(s: &str) -> bool {

--- a/json_typegen_shared/src/lib.rs
+++ b/json_typegen_shared/src/lib.rs
@@ -96,14 +96,10 @@ pub fn codegen(name: &str, input: &str, mut options: Options) -> Result<String, 
 
     let shape = inference::value_to_shape(&sample, &hints);
 
-    let visibility = options.type_visibility.clone();
-    let aliased = options.type_alias_extant_types;
-    let lang = options.output_mode.clone();
-
     let mut generated_code = if options.runnable {
         generation::rust::rust_program(name, &shape, options)
     } else {
-        let (ident, mut defs) = match options.output_mode {
+        let (name, defs) = match options.output_mode {
             OutputMode::Rust => generation::rust::rust_types(name, &shape, options),
             OutputMode::JsonSchema => generation::json_schema::json_schema(name, &shape, options),
             OutputMode::Kotlin => generation::kotlin::kotlin_types(name, &shape, options),
@@ -112,12 +108,7 @@ pub fn codegen(name: &str, input: &str, mut options: Options) -> Result<String, 
                 generation::typescript::typescript_types(name, &shape, options)
             }
         };
-        if aliased {
-            if defs == None {
-                defs = type_alias(&ident, name, &visibility, lang);
-            }
-        }
-        defs.ok_or_else(|| JTError::from(ErrorKind::ExistingType(ident.to_string())))?
+        defs.ok_or_else(|| JTError::from(ErrorKind::ExistingType(name.to_string())))?
     };
 
     if !generated_code.ends_with("\n") {
@@ -125,16 +116,6 @@ pub fn codegen(name: &str, input: &str, mut options: Options) -> Result<String, 
     }
 
     Ok(generated_code)
-}
-
-fn type_alias(ident: &str, name: &str, visibility: &str, mode: OutputMode) -> Option<String> {
-    match mode {
-        OutputMode::Rust | OutputMode::Typescript => {
-            Some(format!("{} type {} = {};", visibility, name, ident))
-        }
-        OutputMode::Kotlin => Some(format!("{} typealias {} = {};", visibility, name, ident)),
-        _ => None,
-    }
 }
 
 /// Parse "names" like `pub(crate) Foo` into a name and a visibility option

--- a/json_typegen_shared/src/lib.rs
+++ b/json_typegen_shared/src/lib.rs
@@ -98,6 +98,7 @@ pub fn codegen(name: &str, input: &str, mut options: Options) -> Result<String, 
 
     let visibility = options.type_visibility.clone();
     let aliased = options.type_alias_extant_types;
+    let lang = options.output_mode.clone();
 
     let mut generated_code = if options.runnable {
         generation::rust::rust_program(name, &shape, options)
@@ -113,7 +114,7 @@ pub fn codegen(name: &str, input: &str, mut options: Options) -> Result<String, 
         };
         if aliased {
             if defs == None {
-                defs = type_alias(&ident, name, &visibility);
+                defs = type_alias(&ident, name, &visibility, lang);
             }
         }
         defs.ok_or_else(|| JTError::from(ErrorKind::ExistingType(ident.to_string())))?
@@ -126,8 +127,14 @@ pub fn codegen(name: &str, input: &str, mut options: Options) -> Result<String, 
     Ok(generated_code)
 }
 
-fn type_alias(ident: &str, name: &str, visibility: &str) -> Option<String> {
-    Some(format!("{} type {} = {};", visibility, name, ident))
+fn type_alias(ident: &str, name: &str, visibility: &str, mode: OutputMode) -> Option<String> {
+    match mode {
+        OutputMode::Rust | OutputMode::Typescript => {
+            Some(format!("{} type {} = {};", visibility, name, ident))
+        }
+        OutputMode::Kotlin => Some(format!("{} typealias {} = {};", visibility, name, ident)),
+        _ => None,
+    }
 }
 
 /// Parse "names" like `pub(crate) Foo` into a name and a visibility option

--- a/json_typegen_shared/src/options.rs
+++ b/json_typegen_shared/src/options.rs
@@ -13,6 +13,7 @@ pub struct Options {
     pub derives: String,
     pub property_name_format: Option<StringTransform>,
     pub(crate) hints: Vec<(String, Hint)>,
+    pub type_alias_extant_types: bool,
 }
 
 impl Default for Options {
@@ -28,6 +29,7 @@ impl Default for Options {
             derives: "Default, Debug, Clone, PartialEq, serde_derive::Serialize, serde_derive::Deserialize".into(),
             property_name_format: None,
             hints: Vec::new(),
+            type_alias_extant_types: false,
         }
     }
 }

--- a/json_typegen_shared/src/parse.rs
+++ b/json_typegen_shared/src/parse.rs
@@ -126,6 +126,9 @@ pub fn options(input: &str) -> Result<Options, String> {
         "allow_option_vec" => boolean_option(remaining, "allow_option_vec", |val| {
             options.allow_option_vec = val;
         }),
+        "type_alias_extant_types" => boolean_option(remaining, "type_alias_extant_types", |val| {
+            options.type_alias_extant_types = val;
+        }),
         key if key.is_empty() || key.starts_with('/') => {
             let (rem, hints) = pointer_block(remaining)?;
             for hint in hints {

--- a/json_typegen_shared/src/util.rs
+++ b/json_typegen_shared/src/util.rs
@@ -84,6 +84,30 @@ fn lowercase_first_letter(s: &str) -> String {
     }
 }
 
+pub(crate) fn alias(
+    name: String,
+    ident: &str,
+    code: Option<String>,
+    options: &crate::options::Options,
+) -> (String, Option<String>) {
+    use crate::options::OutputMode;
+    let alias_keyword = match options.output_mode {
+        OutputMode::Kotlin => "typealias",
+        OutputMode::Rust | OutputMode::Typescript => "type",
+        OutputMode::JsonSchema | OutputMode::Shape => return (name, code),
+    };
+    match (&code, options.type_alias_extant_types) {
+        (None, true) => (
+            name.clone(),
+            Some(format!(
+                "{} {} {} = {};",
+                options.type_visibility, alias_keyword, ident, name
+            )),
+        ),
+        _ => (name, code),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
This is functionality that I need locally, and perhaps it would be useful for others. I'm happy to refactor if needed, I'm not familiar enough with the package to know where the best place to put the new code is. Fixes #19 