### PR TITLE
Add Python (pydantic) generation.

### DIFF
--- a/json_typegen_cli/src/main.rs
+++ b/json_typegen_cli/src/main.rs
@@ -51,6 +51,7 @@ fn main_with_result() -> Result<(), Box<dyn std::error::Error>> {
                     "kotlin",
                     "kotlin/jackson",
                     "kotlin/kotlinx",
+                    "python",
                     "json_schema",
                     "shape",
                 ])

--- a/json_typegen_shared/src/generation.rs
+++ b/json_typegen_shared/src/generation.rs
@@ -1,5 +1,6 @@
 pub mod json_schema;
 pub mod kotlin;
+pub mod python;
 pub mod rust;
 pub mod shape;
 pub mod typescript;

--- a/json_typegen_shared/src/generation/python.rs
+++ b/json_typegen_shared/src/generation/python.rs
@@ -253,7 +253,7 @@ fn generate_data_class(
             let mut field_code = String::new();
             let transformed = apply_transform(ctxt, &field_name, name);
             if transformed != field_name {
-                field_code += &format!(" = {}(alias = \"{}\")", import(ctxt, Import::Field), transformed)
+                field_code += &format!(" = {}(alias=\"{}\")", import(ctxt, Import::Field), transformed)
             }
 
             format!("    {}: {}{}", field_name, field_type, field_code)

--- a/json_typegen_shared/src/generation/python.rs
+++ b/json_typegen_shared/src/generation/python.rs
@@ -1,0 +1,310 @@
+use linked_hash_map::LinkedHashMap;
+use std::collections::HashSet;
+
+use crate::options::{ImportStyle, Options, StringTransform};
+use crate::shape::{self, Shape};
+use crate::to_singular::to_singular;
+use crate::util::{kebab_case, lower_camel_case, snake_case, type_case};
+
+#[derive(PartialEq, PartialOrd, Ord, Eq, Hash, Clone, Copy)]
+enum Import {
+    Any,
+    Optional,
+    BaseModel,
+    Field,
+}
+
+impl Import {
+    fn pair(&self) -> (&'static str, &'static str) {
+        match self {
+            Import::Any => ("typing", "Any"),
+            Import::Optional => ("typing", "Optional"),
+            Import::BaseModel => ("pydantic", "BaseModel"),
+            Import::Field => ("pydantic", "Field"),
+        }
+    }
+    fn identifier(&self) -> &'static str {
+        self.pair().1
+    }
+    fn qualified(&self) -> String {
+        let (module, identifier) = self.pair();
+        format!("{}.{}", module, identifier)
+    }
+}
+
+struct Ctxt {
+    options: Options,
+    type_names: HashSet<String>,
+    imports: HashSet<Import>,
+    created_classes: Vec<(Shape, Ident)>,
+}
+
+pub type Ident = String;
+pub type Code = String;
+
+pub fn python_types(name: &str, shape: &Shape, options: Options) -> Code {
+    let mut ctxt = Ctxt {
+        options,
+        type_names: HashSet::new(),
+        imports: HashSet::new(),
+        created_classes: Vec::new(),
+    };
+
+    if !matches!(shape, Shape::Struct { .. }) {
+        // reserve the requested name
+        ctxt.type_names.insert(name.to_string());
+    }
+
+    let (ident, code) = type_from_shape(&mut ctxt, name, shape);
+    let mut code = code.unwrap_or_default();
+
+    if !ctxt.imports.is_empty() {
+        let mut imports: Vec<_> = ctxt.imports.drain().collect();
+        imports.sort();
+        let mut import_code = String::new();
+        for import in imports {
+            match ctxt.options.import_style {
+                ImportStyle::AssumeExisting => {}
+                ImportStyle::AddImports => {
+                    let (module, identifier) = import.pair();
+                    import_code += &format!("from {} import {}\n", module, identifier);
+                }
+                ImportStyle::QualifiedPaths => {
+                    let (module, identifier) = import.pair();
+                    import_code += &format!("import {}.{}\n", module, identifier);
+                }
+            }
+        }
+        import_code += "\n\n";
+        code = import_code + &code;
+    }
+
+    if ident != name {
+        code += &format!("\n\n{} = {}", name, ident);
+    }
+    code
+}
+
+fn type_from_shape(ctxt: &mut Ctxt, path: &str, shape: &Shape) -> (Ident, Option<Code>) {
+    use crate::shape::Shape::*;
+    match shape {
+        Null | Any | Bottom => (import(ctxt, Import::Any), None),
+        Bool => ("bool".into(), None),
+        StringT => ("str".into(), None),
+        Integer => ("int".into(), None),
+        Floating => ("float".into(), None),
+        Tuple(shapes, _n) => {
+            let folded = shape::fold_shapes(shapes.clone());
+            if shapes.len() <= 3 && folded == Any && shapes.iter().any(|s| s != &Any) {
+                generate_tuple_type(ctxt, path, shapes)
+            } else {
+                generate_vec_type(ctxt, path, &folded)
+            }
+        }
+        VecT { elem_type: e } => generate_vec_type(ctxt, path, e),
+        Struct { fields } => generate_data_class(ctxt, path, fields, shape),
+        MapT { val_type: v } => generate_map_type(ctxt, path, v),
+        Opaque(t) => (t.clone(), None),
+        Optional(e) => {
+            let (inner, defs) = type_from_shape(ctxt, path, e);
+            if ctxt.options.use_default_for_missing_fields {
+                (inner, defs)
+            } else {
+                let optional = import(ctxt, Import::Optional);
+                (format!("{}[{}]", optional, inner), defs)
+            }
+        }
+    }
+}
+
+fn generate_vec_type(ctxt: &mut Ctxt, path: &str, shape: &Shape) -> (Ident, Option<Code>) {
+    let singular = to_singular(path);
+    let (inner, defs) = type_from_shape(ctxt, &singular, shape);
+    (format!("list[{}]", inner), defs)
+}
+
+fn generate_map_type(ctxt: &mut Ctxt, path: &str, shape: &Shape) -> (Ident, Option<Code>) {
+    let singular = to_singular(path);
+    let (inner, defs) = type_from_shape(ctxt, &singular, shape);
+    (format!("dict[str, {}]", inner), defs)
+}
+
+fn generate_tuple_type(ctxt: &mut Ctxt, path: &str, shapes: &[Shape]) -> (Ident, Option<Code>) {
+    let mut types = Vec::new();
+    let mut defs = Vec::new();
+
+    for shape in shapes {
+        let (typ, def) = type_from_shape(ctxt, path, shape);
+        types.push(typ);
+        if let Some(code) = def {
+            defs.push(code)
+        }
+    }
+
+    (
+        format!("tuple[{}]", types.join(", ")),
+        Some(defs.join("\n\n")),
+    )
+}
+
+fn field_name(name: &str, used_names: &HashSet<String>) -> Ident {
+    type_or_field_name(name, used_names, "field", snake_case)
+}
+
+fn type_name(name: &str, used_names: &HashSet<String>) -> Ident {
+    type_or_field_name(name, used_names, "GeneratedType", type_case)
+}
+
+// https://docs.python.org/3/reference/lexical_analysis.html#keywords
+#[rustfmt::skip]
+const PYTHON_KEYWORDS: &[&str] = &[
+    "False", "None", "True",
+    "and", "as", "assert", "async", "await", "break", "class", "continue",
+    "def", "del", "elif", "else", "except", "finally", "for", "from", "global",
+    "if", "import", "in", "is", "lambda", "nonlocal", "not", "or", "pass",
+    "raise", "return", "try", "while", "with", "yield",
+];
+
+fn type_or_field_name(
+    name: &str,
+    used_names: &HashSet<String>,
+    default_name: &str,
+    case_fn: fn(&str) -> String,
+) -> Ident {
+    let name = name.trim();
+    let mut output_name = case_fn(name);
+    if PYTHON_KEYWORDS.contains(&&*output_name) {
+        output_name.push_str("_field");
+    }
+    if output_name.is_empty() {
+        output_name.push_str(default_name);
+    }
+    if let Some(c) = output_name.chars().next() {
+        if c.is_ascii_digit() {
+            output_name = String::from("n") + &output_name;
+        }
+    }
+    if !used_names.contains(&output_name) {
+        return output_name;
+    }
+    for n in 2.. {
+        let temp = format!("{}{}", output_name, n);
+        if !used_names.contains(&temp) {
+            return temp;
+        }
+    }
+    unreachable!()
+}
+
+fn import(ctxt: &mut Ctxt, import: Import) -> String {
+    ctxt.imports.insert(import);
+    match ctxt.options.import_style {
+        ImportStyle::QualifiedPaths => import.qualified(),
+        _ => import.identifier().into(),
+    }
+}
+
+fn generate_data_class(
+    ctxt: &mut Ctxt,
+    path: &str,
+    field_shapes: &LinkedHashMap<String, Shape>,
+    containing_shape: &Shape,
+) -> (Ident, Option<Code>) {
+    for (created_for_shape, ident) in ctxt.created_classes.iter() {
+        if created_for_shape.is_acceptable_substitution_for(containing_shape) {
+            return (ident.into(), None);
+        }
+    }
+
+    let type_name = type_name(path, &ctxt.type_names);
+    ctxt.type_names.insert(type_name.clone());
+    ctxt.created_classes
+        .push((containing_shape.clone(), type_name.clone()));
+
+    let mut field_names = HashSet::new();
+    let mut defs = Vec::new();
+
+    let fields: Vec<Code> = field_shapes
+        .iter()
+        .map(|(name, typ)| {
+            let field_name = field_name(name, &field_names);
+            field_names.insert(field_name.clone());
+
+            let (field_type, child_defs) = type_from_shape(ctxt, name, typ);
+
+            if let Some(code) = child_defs {
+                defs.push(code);
+            }
+
+            let mut field_code = String::new();
+            let transformed = &apply_transform(ctxt, &field_name);
+            if transformed != name {
+                field_code += &format!(" = {}(alias = \"{}\")", import(ctxt, Import::Field), name)
+            }
+
+            format!("    {}: {}{}", field_name, field_type, field_code)
+        })
+        .collect();
+
+    let mut code = String::new();
+
+    code += &format!(
+        "class {}({}):\n",
+        type_name,
+        import(ctxt, Import::BaseModel)
+    );
+
+    if fields.is_empty() {
+        code += "    pass\n";
+    } else {
+        code += &fields.join("\n");
+        code += "\n";
+    }
+
+    if !defs.is_empty() {
+        let mut d = defs.join("\n\n");
+        d += "\n\n";
+        d += &code;
+        code = d;
+    }
+
+    (type_name, Some(code))
+}
+
+fn apply_transform(ctxt: &Ctxt, field_name: &str) -> String {
+    match ctxt.options.property_name_format {
+        Some(StringTransform::LowerCase) => field_name.to_ascii_lowercase(),
+        Some(StringTransform::PascalCase) => type_case(field_name),
+        Some(StringTransform::SnakeCase) => snake_case(field_name),
+        Some(StringTransform::KebabCase) => kebab_case(field_name),
+        Some(StringTransform::UpperCase) => field_name.to_ascii_uppercase(),
+        Some(StringTransform::CamelCase) => lower_camel_case(field_name),
+        Some(StringTransform::ScreamingSnakeCase) => snake_case(field_name).to_ascii_uppercase(),
+        Some(StringTransform::ScreamingKebabCase) => kebab_case(field_name).to_ascii_uppercase(),
+        None => field_name.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod python_codegen_tests {
+    use super::*;
+
+    #[test]
+    fn field_names_test() {
+        fn field_name_test(from: &str, to: &str) {
+            assert_eq!(
+                field_name(from, &HashSet::new()),
+                to.to_string(),
+                r#"From "{}" to "{}""#,
+                from,
+                to
+            );
+        }
+
+        field_name_test("valid", "valid");
+        field_name_test("1", "n1");
+        field_name_test("+1", "n1");
+        field_name_test("", "field");
+        field_name_test("def", "def_field");
+    }
+}

--- a/json_typegen_shared/src/generation/python.rs
+++ b/json_typegen_shared/src/generation/python.rs
@@ -239,7 +239,7 @@ fn generate_data_class(
             let mut field_code = String::new();
             let transformed = &apply_transform(ctxt, &field_name);
             if transformed != name {
-                field_code += &format!(" = {}(alias = \"{}\")", import(ctxt, Import::Field), name)
+                field_code += &format!(" = {}(alias = \"{}\")", import(ctxt, Import::Field), transformed)
             }
 
             format!("    {}: {}{}", field_name, field_type, field_code)

--- a/json_typegen_shared/src/generation/python.rs
+++ b/json_typegen_shared/src/generation/python.rs
@@ -90,7 +90,10 @@ pub fn python_types(name: &str, shape: &Shape, options: Options) -> Code {
     }
 
     if ident != name {
-        code += &format!("\n\n{} = {}", name, ident);
+        if !code.is_empty() {
+            code += "\n\n";
+        }
+        code += &format!("{} = {}", name, ident);
     }
     code
 }

--- a/json_typegen_shared/src/generation/python.rs
+++ b/json_typegen_shared/src/generation/python.rs
@@ -237,8 +237,8 @@ fn generate_data_class(
             }
 
             let mut field_code = String::new();
-            let transformed = &apply_transform(ctxt, &field_name);
-            if transformed != name {
+            let transformed = apply_transform(ctxt, &field_name, &name);
+            if transformed != field_name {
                 field_code += &format!(" = {}(alias = \"{}\")", import(ctxt, Import::Field), transformed)
             }
 
@@ -271,7 +271,7 @@ fn generate_data_class(
     (type_name, Some(code))
 }
 
-fn apply_transform(ctxt: &Ctxt, field_name: &str) -> String {
+fn apply_transform(ctxt: &Ctxt, field_name: &str, name: &str) -> String {
     match ctxt.options.property_name_format {
         Some(StringTransform::LowerCase) => field_name.to_ascii_lowercase(),
         Some(StringTransform::PascalCase) => type_case(field_name),
@@ -281,7 +281,7 @@ fn apply_transform(ctxt: &Ctxt, field_name: &str) -> String {
         Some(StringTransform::CamelCase) => lower_camel_case(field_name),
         Some(StringTransform::ScreamingSnakeCase) => snake_case(field_name).to_ascii_uppercase(),
         Some(StringTransform::ScreamingKebabCase) => kebab_case(field_name).to_ascii_uppercase(),
-        None => field_name.to_string(),
+        None => name.to_string(),
     }
 }
 

--- a/json_typegen_shared/src/generation/python.rs
+++ b/json_typegen_shared/src/generation/python.rs
@@ -83,8 +83,10 @@ pub fn python_types(name: &str, shape: &Shape, options: Options) -> Code {
                 }
             }
         }
-        import_code += "\n\n";
-        code = import_code + &code;
+        if !import_code.is_empty(){
+            import_code += "\n\n";
+            code = import_code + &code;
+        }
     }
 
     if ident != name {
@@ -145,7 +147,9 @@ fn generate_tuple_type(ctxt: &mut Ctxt, path: &str, shapes: &[Shape]) -> (Ident,
         let (typ, def) = type_from_shape(ctxt, path, shape);
         types.push(typ);
         if let Some(code) = def {
-            defs.push(code)
+            if !code.is_empty() {
+                defs.push(code)
+            }
         }
     }
 
@@ -241,7 +245,9 @@ fn generate_data_class(
             let (field_type, child_defs) = type_from_shape(ctxt, name, typ);
 
             if let Some(code) = child_defs {
-                defs.push(code);
+                if !code.is_empty() {
+                    defs.push(code);
+                }
             }
 
             let mut field_code = String::new();

--- a/json_typegen_shared/src/generation/python.rs
+++ b/json_typegen_shared/src/generation/python.rs
@@ -95,7 +95,7 @@ fn type_from_shape(ctxt: &mut Ctxt, path: &str, shape: &Shape) -> (Ident, Option
         Floating => ("float".into(), None),
         Tuple(shapes, _n) => {
             let folded = shape::fold_shapes(shapes.clone());
-            if shapes.len() <= 3 && folded == Any && shapes.iter().any(|s| s != &Any) {
+            if folded == Any && shapes.iter().any(|s| s != &Any) {
                 generate_tuple_type(ctxt, path, shapes)
             } else {
                 generate_vec_type(ctxt, path, &folded)

--- a/json_typegen_shared/src/generation/python.rs
+++ b/json_typegen_shared/src/generation/python.rs
@@ -23,6 +23,9 @@ impl Import {
             Import::Field => ("pydantic", "Field"),
         }
     }
+    fn module(&self) -> &'static str {
+        self.pair().0
+    }
     fn identifier(&self) -> &'static str {
         self.pair().1
     }
@@ -70,8 +73,7 @@ pub fn python_types(name: &str, shape: &Shape, options: Options) -> Code {
                     import_code += &format!("from {} import {}\n", module, identifier);
                 }
                 ImportStyle::QualifiedPaths => {
-                    let (module, identifier) = import.pair();
-                    import_code += &format!("import {}.{}\n", module, identifier);
+                    import_code += &format!("import {}\n", import.module());
                 }
             }
         }

--- a/json_typegen_shared/src/lib.rs
+++ b/json_typegen_shared/src/lib.rs
@@ -124,6 +124,7 @@ pub fn codegen_from_shape(name: &str, shape: &Shape, options: Options) -> Result
         OutputMode::TypescriptTypeAlias => {
             generation::typescript_type_alias::typescript_type_alias(name, shape, options)
         }
+        OutputMode::PythonPydantic => generation::python::python_types(name, shape, options),
     };
 
     // Ensure generated code ends with exactly one newline

--- a/json_typegen_shared/src/options.rs
+++ b/json_typegen_shared/src/options.rs
@@ -80,6 +80,7 @@ pub enum OutputMode {
     TypescriptTypeAlias,
     KotlinJackson,
     KotlinKotlinx,
+    PythonPydantic,
     JsonSchema,
     Shape,
 }
@@ -93,6 +94,7 @@ impl OutputMode {
             "kotlin" => Some(OutputMode::KotlinJackson),
             "kotlin/jackson" => Some(OutputMode::KotlinJackson),
             "kotlin/kotlinx" => Some(OutputMode::KotlinKotlinx),
+            "python" => Some(OutputMode::PythonPydantic),
             "json_schema" => Some(OutputMode::JsonSchema),
             "shape" => Some(OutputMode::Shape),
             _ => None,

--- a/json_typegen_shared/tests/python_generation.rs
+++ b/json_typegen_shared/tests/python_generation.rs
@@ -7,8 +7,7 @@ fn code_output_test(name: &str, input: &str, expected: &str) {
     options.output_mode = OutputMode::PythonPydantic;
     let res = codegen(name, input, options);
     let output = res.unwrap();
-    let expected = expected.trim();
-    let output = output.trim();
+    let expected = &expected[1..];
     assert_eq!(
         output,
         expected,
@@ -40,7 +39,9 @@ fn list_of_numbers() {
         r##"
             [1, 2, 3]
         "##,
-        "Numbers = list[int]"
+        "
+Numbers = list[int]
+"
     );
 }
 

--- a/json_typegen_shared/tests/python_generation.rs
+++ b/json_typegen_shared/tests/python_generation.rs
@@ -1,0 +1,217 @@
+use json_typegen_shared::{codegen, ImportStyle, Options, OutputMode};
+
+/// Function to test AST equality, not string equality
+fn code_output_test(name: &str, input: &str, expected: &str) {
+    let mut options = Options::default();
+    options.import_style = ImportStyle::AssumeExisting;
+    options.output_mode = OutputMode::PythonPydantic;
+    let res = codegen(name, input, options);
+    let output = res.unwrap();
+    let expected = expected.trim();
+    let output = output.trim();
+    assert_eq!(
+        output,
+        expected,
+        "\n\nUnexpected output code:\n  input: {}\n  output:\n{}\n  expected: {}",
+        input,
+        output,
+        expected
+    );
+}
+
+#[test]
+fn empty_object() {
+    code_output_test(
+        "Root",
+        r##"
+            {}
+        "##,
+        r##"
+class Root(BaseModel):
+    pass
+"##,
+    );
+}
+
+#[test]
+fn list_of_numbers() {
+    code_output_test(
+        "Numbers",
+        r##"
+            [1, 2, 3]
+        "##,
+        "Numbers = list[int]"
+    );
+}
+
+#[test]
+fn point() {
+    code_output_test(
+        "Point",
+        r##"
+            {
+                "x": 2,
+                "y": 3
+            }
+        "##,
+        r##"
+class Point(BaseModel):
+    x: int
+    y: int
+"##,
+    );
+}
+
+#[test]
+fn optionals() {
+    code_output_test(
+        "Opts",
+        r##"
+            [
+                {
+                    "in_both": 5,
+                    "missing": 5,
+                    "has_null": 5
+                },
+                {
+                    "in_both": 5,
+                    "has_null": null,
+                    "added": 5
+                }
+            ]
+        "##,
+        r##"
+class Opt(BaseModel):
+    in_both: int
+    missing: Optional[int]
+    has_null: Optional[int]
+    added: Optional[int]
+
+
+Opts = list[Opt]
+"##,
+    );
+}
+
+#[test]
+fn fallback() {
+    code_output_test(
+        "FallbackExamples",
+        r##"
+            [
+                {
+                    "only_null": null,
+                    "conflicting": 5,
+                    "empty_array": []
+                },
+                {
+                    "only_null": null,
+                    "conflicting": "five",
+                    "empty_array": []
+                }
+            ]
+        "##,
+        r##"
+class FallbackExample(BaseModel):
+    only_null: Any
+    conflicting: Any
+    empty_array: list[Any]
+
+
+FallbackExamples = list[FallbackExample]
+"##,
+    );
+}
+
+#[test]
+fn nesting() {
+    code_output_test(
+        "NestedTypes",
+        r##"
+            [
+                {
+                    "nested": {
+                        "a": 5,
+                        "doubly_nested": { "c": 10 }
+                    },
+                    "in_array": [{ "b": 5 }]
+                }
+            ]
+        "##,
+        r##"
+class DoublyNested(BaseModel):
+    c: int
+
+
+class Nested(BaseModel):
+    a: int
+    doubly_nested: DoublyNested
+
+
+class InArray(BaseModel):
+    b: int
+
+
+class NestedType(BaseModel):
+    nested: Nested
+    in_array: list[InArray]
+
+
+NestedTypes = list[NestedType]
+"##,
+    );
+}
+
+#[test]
+fn tuple() {
+    code_output_test(
+        "Pagination",
+        r##"
+            [
+                {
+                    "pages": 1,
+                    "items": 3
+                },
+                [
+                    {
+                        "name": "John"
+                    },
+                    {
+                        "name": "James"
+                    },
+                    {
+                        "name": "Jake"
+                    }
+                ]
+            ]
+        "##,
+        r##"
+class Pagination2(BaseModel):
+    pages: int
+    items: int
+
+
+class Pagination3(BaseModel):
+    name: str
+
+
+Pagination = tuple[Pagination2, list[Pagination3]]
+"##,
+    );
+}
+
+#[test]
+fn rename() {
+    code_output_test(
+        "Renamed",
+        r##"
+            {
+                "class": 5
+            }
+        "##,
+        r##"
+class Renamed(BaseModel):
+    class_field: int = Field(alias="class")
+"##,
+    );
+}

--- a/json_typegen_web/src/download.js
+++ b/json_typegen_web/src/download.js
@@ -7,6 +7,7 @@ function createFilename(typename, output_mode) {
         "typescript/typealias": "ts",
         "kotlin/jackson": "kt",
         "kotlin/kotlinx": "kt",
+        "python": "py",
         "json_schema": "json",
         "shape": "json",
     }

--- a/json_typegen_web/src/index.html
+++ b/json_typegen_web/src/index.html
@@ -184,6 +184,7 @@
                   <option value="typescript/typealias">Typescript (single typealias)</option>
                   <option value="kotlin/jackson">Kotlin (Jackson)</option>
                   <option value="kotlin/kotlinx">Kotlin (kotlinx.serialization)</option>
+                  <option value="python">Python (pydantic)</option>
                   <option value="json_schema">JSON Schema</option>
                   <option value="shape">Shape (internal representation)</option>
                 </select>

--- a/json_typegen_web/src/index.js
+++ b/json_typegen_web/src/index.js
@@ -86,8 +86,8 @@ worker.onmessage = messageEvent => {
 
 function toggleOptions() {
   const conditionalOptions = ({
-    propertynameformat: ['rust', 'kotlin/jackson'],
-    importstyle: ['rust', 'kotlin/jackson', 'kotlin/kotlinx'],
+    propertynameformat: ['rust', 'kotlin/jackson', 'python'],
+    importstyle: ['rust', 'kotlin/jackson', 'kotlin/kotlinx', 'python'],
     collectadditional: ['rust', 'kotlin/jackson'],
   });
   const currentOutputmode = $('outputmode').value;


### PR DESCRIPTION
Add Python [pydantic][1] generation. Most code originates from https://github.com/evestera/json_typegen/blob/d572c1eefd29d23f57961262b68eb9c130fc95fe/json_typegen_shared/src/generation/kotlin.rs .

[1]: https://pydantic-docs.helpmanual.io/