### PR TITLE
Distinction between nullable and optional

### DIFF
--- a/json_typegen_shared/src/generation/json_schema.rs
+++ b/json_typegen_shared/src/generation/json_schema.rs
@@ -53,6 +53,7 @@ fn type_from_shape(ctxt: &mut Ctxt, path: &str, shape: &Shape) -> Value {
         MapT { val_type: v } => generate_map_type(ctxt, path, v),
         Opaque(t) => Value::Object(string_hashmap! { "type" => Value::String(t.clone()) }),
         Optional(e) => type_from_shape(ctxt, path, e),
+        Nullable(e) => type_from_shape(ctxt, path, e),
     }
 }
 

--- a/json_typegen_shared/src/generation/kotlin.rs
+++ b/json_typegen_shared/src/generation/kotlin.rs
@@ -80,6 +80,14 @@ fn type_from_shape(ctxt: &mut Ctxt, path: &str, shape: &Shape) -> (Ident, Option
             } else {
                 (format!("{}?", inner), defs)
             }
+        },
+        Nullable(e) => {
+            let (inner, defs) = type_from_shape(ctxt, path, e);
+            if ctxt.options.use_default_for_missing_fields {
+                (inner, defs)
+            } else {
+                (format!("{}?", inner), defs)
+            }
         }
     }
 }

--- a/json_typegen_shared/src/generation/python.rs
+++ b/json_typegen_shared/src/generation/python.rs
@@ -126,6 +126,15 @@ fn type_from_shape(ctxt: &mut Ctxt, path: &str, shape: &Shape) -> (Ident, Option
                 let optional = import(ctxt, Import::Optional);
                 (format!("{}[{}]", optional, inner), defs)
             }
+        },
+        Nullable(e) => {
+            let (inner, defs) = type_from_shape(ctxt, path, e);
+            if ctxt.options.use_default_for_missing_fields {
+                (inner, defs)
+            } else {
+                let optional = import(ctxt, Import::Optional);
+                (format!("{}[{}]", optional, inner), defs)
+            }
         }
     }
 }

--- a/json_typegen_shared/src/generation/rust.rs
+++ b/json_typegen_shared/src/generation/rust.rs
@@ -94,7 +94,15 @@ fn type_from_shape(ctxt: &mut Ctxt, path: &str, shape: &Shape) -> (Ident, Option
             } else {
                 (format!("Option<{}>", inner), defs)
             }
-        }
+        },
+        Nullable(e) => {
+            let (inner, defs) = type_from_shape(ctxt, path, e);
+            if ctxt.options.use_default_for_missing_fields {
+                (inner, defs)
+            } else {
+                (format!("Option<{}>", inner), defs)
+            }
+        },
     }
 }
 

--- a/json_typegen_shared/src/generation/shape.rs
+++ b/json_typegen_shared/src/generation/shape.rs
@@ -46,6 +46,10 @@ fn type_from_shape(ctxt: &mut Ctxt, shape: &Shape) -> Value {
             "__type__" => Value::Str("optional"),
             "item" => type_from_shape(ctxt, e),
         }),
+        Nullable(e) => Value::Object(string_hashmap! {
+            "__type__" => Value::Str("nullable"),
+            "item" => type_from_shape(ctxt, e),
+        }),
     }
 }
 

--- a/json_typegen_shared/src/generation/typescript.rs
+++ b/json_typegen_shared/src/generation/typescript.rs
@@ -64,6 +64,10 @@ fn type_from_shape(ctxt: &mut Ctxt, path: &str, shape: &Shape) -> (Ident, Option
             } else {
                 (format!("{} | undefined", inner), defs)
             }
+        },
+        Nullable(e) => {
+            let (inner, defs) = type_from_shape(ctxt, path, e);
+            (format!("{} | null", inner), defs)
         }
     }
 }

--- a/json_typegen_shared/src/generation/typescript_type_alias.rs
+++ b/json_typegen_shared/src/generation/typescript_type_alias.rs
@@ -49,7 +49,15 @@ fn type_from_shape(ctxt: &mut Ctxt, shape: &Shape) -> Code {
             } else {
                 format!("{} | undefined", inner)
             }
-        }
+        },
+        Nullable(e) => {
+            let inner = type_from_shape(ctxt, e);
+            if ctxt.options.use_default_for_missing_fields {
+                inner
+            } else {
+                format!("{} | null", inner)
+            }
+        },
     }
 }
 


### PR DESCRIPTION
Hi! Similar to #21 when using this library to generate TS types, it's often useful to make a distinction between `nullable` and `optional` fields.
I'm looking for feedback on this PR as I'm **very** new to Rust. Currently not all tests are passing and before investing more time I'd like to know if the approach I took is ok.

Input
```json
{
  "a": [{ "nullable": 1 }, { "nullable": null }],
  "b": [
    {
      "optional": 1,
      "always": true
    },
    {
      "always": true
    }
  ],
  "c": [
    {
      "optionalNullable": 1,
      "always": true
    },
    {
      "optionalNullable": null,
      "always": true
    },
    {
      "always": true
    }
  ]
}
```


Before the changes
```ts
export interface A {
    nullable?: number;
}

export interface B {
    optional?: number;
    always: boolean;
}

export interface C {
    optionalNullable?: number;
    always: boolean;
}
```

After the changes
```ts
export interface A {
    nullable: number | null;
}

export interface B {
    optional?: number;
    always: boolean;
}

export interface C {
    optionalNullable?: number | null;
    always: boolean;
}
```