### PR TITLE
json_typgen_wasm: replaced unmaintained wee_alloc

### DIFF
--- a/json_typegen_shared/Cargo.toml
+++ b/json_typegen_shared/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = "1.0"
 linked-hash-map = "0.5.4"
 syn = { version = "0.11", features = ["full", "parsing"], optional = true }
 synom = { version = "0.11.3", optional = true }
-indicatif = { version = "0.16.2", optional = true }
+indicatif = { version = "0.18.0", optional = true }
 sqlparser = "0.36.1"
 
 [dev-dependencies]

--- a/json_typegen_shared/src/hints.rs
+++ b/json_typegen_shared/src/hints.rs
@@ -71,27 +71,27 @@ impl<'a> Hints<'a> {
     }
 
     /// ([/a/b, /a/c, /d/e], "a") -> [/b, /c]
-    pub fn step_field(&self, name: &str) -> Hints {
+    pub fn step_field(&self, name: &str) -> Hints<'_> {
         self.step(|first| first == "-" || first == name)
     }
 
     /// [/1/b, /a/c, /-/e] -> [/b, /c, /e]
-    pub fn step_any(&self) -> Hints {
+    pub fn step_any(&self) -> Hints<'_> {
         self.step(|_first| true)
     }
 
     /// [/1/b, /a/c, /-/e] -> [/b, /e]
-    pub fn step_array(&self) -> Hints {
+    pub fn step_array(&self) -> Hints<'_> {
         self.step(is_index)
     }
 
     /// ([/2/b, /a/c, /-/e, /3/d], 3) -> [/e, /d]
-    pub fn step_index(&self, index: usize) -> Hints {
+    pub fn step_index(&self, index: usize) -> Hints<'_> {
         let i_str = &index.to_string();
         self.step(|first| first == "-" || first == i_str)
     }
 
-    fn step<F: Fn(&str) -> bool>(&self, pred: F) -> Hints {
+    fn step<F: Fn(&str) -> bool>(&self, pred: F) -> Hints<'_> {
         let mut filtered = Vec::new();
         let mut applicable = Vec::new();
 

--- a/json_typegen_shared/src/lib.rs
+++ b/json_typegen_shared/src/lib.rs
@@ -162,7 +162,7 @@ fn handle_pub_in_name<'a>(name: &'a str, options: &mut Options) -> &'a str {
     name
 }
 
-fn infer_source_type(s: &str) -> SampleSource {
+fn infer_source_type(s: &str) -> SampleSource<'_> {
     let s = s.trim();
     if s.starts_with('{') || s.starts_with('[') {
         return SampleSource::Text(s);

--- a/json_typegen_shared/src/progress.rs
+++ b/json_typegen_shared/src/progress.rs
@@ -14,9 +14,9 @@ impl FileWithProgress {
         let len = file.metadata()?.len();
         Ok(FileWithProgress {
             file,
-            progress: ProgressBar::new(len).with_style(ProgressStyle::default_bar().template(
+            progress: ProgressBar::new(len).with_style(ProgressStyle::with_template(
                 "[{elapsed_precise}] {bar:40.cyan/blue} {bytes}/{total_bytes} Processing file...",
-            )),
+            ).unwrap()),
         })
     }
 }

--- a/json_typegen_wasm/Cargo.toml
+++ b/json_typegen_wasm/Cargo.toml
@@ -23,10 +23,9 @@ json_typegen_shared = { path = "../json_typegen_shared", default-features = fals
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.5", optional = true }
 
-# `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
-# compared to the default allocator's ~10K. It is slower than the default
-# allocator, however.
-wee_alloc = { version = "0.4.2", optional = true }
+# `lol_alloc` is drop-in replacement for the abandoned wee_alloc with size < 1KB and free
+# of memory leak issues.
+lol_alloc = { version = "0.4", optional = true }
 
 [features]
 #default = ["console_error_panic_hook"]

--- a/json_typegen_wasm/src/lib.rs
+++ b/json_typegen_wasm/src/lib.rs
@@ -13,11 +13,13 @@ cfg_if! {
 }
 
 cfg_if! {
-    // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
-    // allocator.
-    if #[cfg(feature = "wee_alloc")] {
+    // When the `lol_alloc` feature is enabled, use `lol_alloc` as the global
+    // allocator. This is a maintained replacement for the abandoned wee_alloc.
+    if #[cfg(all(feature = "lol_alloc", target_arch = "wasm32"))] {
+        use lol_alloc::{FreeListAllocator, LockedAllocator};
+
         #[global_allocator]
-        static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+        static ALLOC: LockedAllocator<FreeListAllocator> = LockedAllocator::new(FreeListAllocator::new());
     }
 }
 


### PR DESCRIPTION
## Motivation

`wee_alloc` has been long unmaintained and also leaked memory according to the [reports](https://www.reddit.com/r/rust/comments/x1cle0/dont_use_wee_alloc_in_production_code_targeting)

## Replacement

`lol_alloc` is no-fun solid allocator with memory footprint <1KB which justified its choice as a replacement.